### PR TITLE
feat: inactivity tracker now adds/removes activity roles

### DIFF
--- a/modules/kok-bot/modules/common/events/index.js
+++ b/modules/kok-bot/modules/common/events/index.js
@@ -31,7 +31,7 @@ client.on("presenceUpdate", (oldMember, newMember) => {
                 console.log("checking complete");
             })
             .catch(err => {
-                console.log(err);
+                logger.log(err);
             })
     }
 });

--- a/modules/kok-bot/modules/inactive-tracker/mark.js
+++ b/modules/kok-bot/modules/inactive-tracker/mark.js
@@ -1,13 +1,49 @@
 const GuildController = require('../controllers/guild-controller');
+const discordUsers = require('../../../../models/discord-users');
+const logger = require('../../../logger')
 
 module.exports = (member) => {
     return GuildController.find(member.guild.id)
-        .then(guild=>{
-            if (!guild) {return console.log('no such guild found')}
-            if (!guild.inactiveRole) {return console.log('no inactiveRole set')}
+        //finds guild model and handles fail conditions
+        .then(guild => {
+            if (!guild) { return logger.log('no such guild found') }
+            if (!guild.inactiveRole) { return logger.log('no inactiveRole set') }
+            //checks each role on member if it's an Activity Role
+            //if it is, then it is removed and a record kept on their entry in the DB
+
+            discordUsers.findOneOrCreate({ guildID: member.guild.id }, { guildID: member.guild.id })
+                .then(usersGuild => {
+                    //create collection of Active Roles to be removed and recorded
+                    let activityRoles = [];
+                    member.roles.forEach(role => {
+                        if (guild.activityRoles.indexOf(role.id) > -1) {
+                            activityRoles.push(role.id);
+                            member.removeRole(role.id);
+                        }
+                    })
+
+                    //looks for this user amongst all the users
+                    let foundUser = usersGuild.users.find(user => {
+                        return user.id === member.id;
+                    })
+                    //if they're not found then they should be added
+                    if (!foundUser) {
+                        usersGuild.users.addToSet({
+                            id: member.id,
+                            activityRolesRemoved: activityRoles
+                        });
+                    } else {
+                        activityRoles.forEach(role=>{
+                            foundUser.activityRolesRemoved.addToSet(role);
+                        });
+                    }
+
+                    usersGuild.save();
+                })
+
             return member.addRole(guild.inactiveRole);
         })
-        .catch(err=>{
-            console.log(err);
+        .catch(err => {
+            logger.log(err);
         })
 }

--- a/modules/kok-bot/modules/inactive-tracker/unmark.js
+++ b/modules/kok-bot/modules/inactive-tracker/unmark.js
@@ -1,13 +1,27 @@
 const GuildController = require('../controllers/guild-controller');
+const discordUsers = require('../../../../models/discord-users');
+const logger = require('../../../logger')
 
 module.exports = (member) => {
     return GuildController.find(member.guild.id)
-        .then(guild=>{
-            if (!guild) {return console.log('no such guild found')}
-            if (!guild.inactiveRole) {return console.log('no inactiveRole set')}
+        .then(guild => {
+            if (!guild) { return console.log('no such guild found') }
+            if (!guild.inactiveRole) { return console.log('no inactiveRole set') }
             return member.removeRole(guild.inactiveRole);
         })
-        .catch(err=>{
-            console.log(err);
+        .then(member => {
+            discordUsers.findOneOrCreate({ guildID: member.guild.id }, { guildID: member.guild.id })
+                .then(guild => {
+                    let foundUser = guild.users.find(user => user.id === member.id);
+                    if (!foundUser) { return new Error("no such user")}
+                    member.addRoles(foundUser.activityRolesRemoved)
+                        .then(() => {
+                            foundUser.activityRolesRemoved = undefined;
+                            guild.save();
+                        })
+                })
+        })
+        .catch(err => {
+            logger.log(err);
         })
 }


### PR DESCRIPTION
Previously inactivity tracker simply added an inactive role to each member and then removed it when they returned. Now all roles that are flagged as 'activity roles' will be removed, and then reapplied should they become active again